### PR TITLE
Fixed error and warning

### DIFF
--- a/src/main/java/com/twocentsforthoughts/dropzone/client/Dropzone.java
+++ b/src/main/java/com/twocentsforthoughts/dropzone/client/Dropzone.java
@@ -181,6 +181,7 @@ public class Dropzone extends Composite {
 	@Override
 	protected void onAttach() {
 		initDropzone(getElement(), options, handler, dictionary);
+		super.onAttach();
 	}
 
 }

--- a/src/main/java/com/twocentsforthoughts/dropzone/client/Options.java
+++ b/src/main/java/com/twocentsforthoughts/dropzone/client/Options.java
@@ -77,7 +77,7 @@ class Options extends JavaScriptObject implements DropzoneOptions {
 	@Override
 	public final void setHeaders(Map<String, String> headers) {
 		if (headers == null) {
-			headers = Collections.EMPTY_MAP;
+			headers = Collections.emptyMap();
 		}
 
 		MapOverlay mapOverlay = MapOverlay.create();


### PR DESCRIPTION
Hi,

I have made two changes that addresses one console error and one console warning.

1. Error in onAttach() method - super.onAttach() was never called, making gwt complains about it in browser console.
2. Compiler warning when using collections.EMPTY_MAP.

Marko
