### PR TITLE
Fixed bug with removing files from dropzone

### DIFF
--- a/src/main/java/com/twocentsforthoughts/dropzone/client/Dropzone.java
+++ b/src/main/java/com/twocentsforthoughts/dropzone/client/Dropzone.java
@@ -292,7 +292,7 @@ public class Dropzone extends Composite {
 	 */
 	private native void removeFileNative(Element e, int i) /*-{
 		if (e.dropzone.files[i]!=null){
-        	e.dropzone.removeFile(e.dropzone.files[0]);
+        	e.dropzone.removeFile(e.dropzone.files[i]);
 		}
 	}-*/;
 	


### PR DESCRIPTION
When removing files from dropzone, removeFile(i) was always removing first file instead of given file.