### PR TITLE
Fixed setting custom header values. Previously, the header param name…

### DIFF
--- a/src/main/java/com/github/andrezimmermann/dropzone/client/MapOverlay.java
+++ b/src/main/java/com/github/andrezimmermann/dropzone/client/MapOverlay.java
@@ -18,7 +18,7 @@ class MapOverlay extends JavaScriptObject {
     }
 
     public native final void put(String key, String value)/*-{
-		this.key = value;
+		this[key] = value;
     }-*/;
 
 }


### PR DESCRIPTION
Setting a custom header param was resulting in the param name being set to "key" regardless of what param name was specified. This was due to using "this.key" Javascript syntax instead of "this[key]".